### PR TITLE
Bugfix: Batch Operations Settle Matured Assets

### DIFF
--- a/contracts/CashMarket.sol
+++ b/contracts/CashMarket.sol
@@ -310,9 +310,6 @@ contract CashMarket is Governed {
         _isValidBlock(maturity, maxTime);
         uint32 timeToMaturity = maturity - uint32(block.timestamp);
         Market memory market = markets[maturity];
-        // We call settle here instead of at the end of the function because if we have matured liquidity
-        // tokens this will put cash back into our portfolio so that we can add it back into the markets.
-        Portfolios().settleMaturedAssets(account);
 
         uint128 fCash;
         uint128 liquidityTokenAmount;

--- a/contracts/ERC1155Trade.sol
+++ b/contracts/ERC1155Trade.sol
@@ -73,8 +73,12 @@ contract ERC1155Trade is ERC1155Base {
         if (deposits.length > 0 || msg.value != 0) Escrow().depositsOnBehalf{value: msg.value}(account, deposits);
         if (trades.length > 0) _batchTrade(account, trades);
 
-        (int256 fc, /* int256[] memory */, /* int256[] memory */) = Portfolios().freeCollateralView(account);
-        require(fc >= 0, $$(ErrorCode(INSUFFICIENT_FREE_COLLATERAL)));
+        // If there are only deposits then free collateral will only increase and we do not want to run a check against
+        // it in case an account deposits collateral but is still undercollateralized
+        if (trades.length > 0) {
+            (int256 fc, /* int256[] memory */, /* int256[] memory */) = Portfolios().freeCollateralView(account);
+            require(fc >= 0, $$(ErrorCode(INSUFFICIENT_FREE_COLLATERAL)));
+        }
 
         emit BatchOperation(account, msg.sender);
     }

--- a/kovan.json
+++ b/kovan.json
@@ -8,7 +8,7 @@
   "directory": "0xdce848258dFB1bBf34C346Fbe40F10F8a42d2526",
   "erc1155": "0x3a31b8121D810B1D7b3004f94f205E6DFC1bf8d9",
   "erc1155trade": "0xBbA899578bd3fA3DAa863A340f5600797993eF08",
-  "cashMarketLogic": "0x035cb048a96a5132120ee940a08A6D5E00D63A42",
+  "cashMarketLogic": "0x091923900CCAEAB2DFCCE766Ad0EB27B162fC699",
   "startBlock": 21065054,
   "defaultConfirmations": 3,
   "libraries": {
@@ -18,12 +18,12 @@
   "deployedCodeHash": {
     "Liquidation": "0xf36bdfe65106d4addfa27de6d5200f61c16950bc7e286204184b2a132fe55331",
     "RiskFramework": "0xf9453b18228638bee1e481aab7db30cd30df8ae5bfad3cbb6893cdd3c21281bb",
-    "CashMarket": "0x5044c667b1a47f5138261f97a089eadea1751c7066fdded7487b8c1db087b9dd",
+    "CashMarket": "0x2b87e487335d31b68acc63fceb962b66c901ab56c19b481021d260b29ca7ed46",
     "Directory": "0xdb138f0d75fdc52b8516c5be3716c51c5770d86b68cc9b22213e61905863b413",
     "Escrow": "0x182071f45a19edf0fa4d2d65a0d490e5bcb1f609c2ad64c840c0244b885e42ef",
     "Portfolios": "0xeb21ab15cf0bfbd7fea1f211ba493fa431a7fe63695d9138241f120457488f3c",
     "ERC1155Token": "0x26fbb2940acc7ee6c8574c38f6a0150f3c58094c006b7ccf00d851cfb387c701",
-    "ERC1155Trade": "0x395e77fb8c84e2f9eb3efdfc8f2b564c7080ef0d2b79613c14945c17ec312cdf"
+    "ERC1155Trade": "0x694355c2884a2e2c98d10eb0170fafb2dd92a1220d9a5acd8525035109ad5cf4"
   },
-  "gitHash": "7b69dcaaa22c975dde7c952be0a099cefe1d750e"
+  "gitHash": "3c826bcacadc61bfc434d64de4a18a8aeac14de0"
 }

--- a/mainnet.json
+++ b/mainnet.json
@@ -8,7 +8,7 @@
   "directory": "0xdce848258dFB1bBf34C346Fbe40F10F8a42d2526",
   "erc1155": "0x3a31b8121D810B1D7b3004f94f205E6DFC1bf8d9",
   "erc1155trade": "0xBbA899578bd3fA3DAa863A340f5600797993eF08",
-  "cashMarketLogic": "0x2bEb7f2041F43f3e31eBCc33b7020D9642d1692c",
+  "cashMarketLogic": "0x307885bb78D490cF9198D678F8B2D1058D741F93",
   "startBlock": 11003692,
   "defaultConfirmations": 3,
   "libraries": {
@@ -18,12 +18,12 @@
   "deployedCodeHash": {
     "Liquidation": "0xf36bdfe65106d4addfa27de6d5200f61c16950bc7e286204184b2a132fe55331",
     "RiskFramework": "0xf9453b18228638bee1e481aab7db30cd30df8ae5bfad3cbb6893cdd3c21281bb",
-    "CashMarket": "0x5044c667b1a47f5138261f97a089eadea1751c7066fdded7487b8c1db087b9dd",
+    "CashMarket": "0x2b87e487335d31b68acc63fceb962b66c901ab56c19b481021d260b29ca7ed46",
     "Directory": "0x081ac9368fe5dd38ab9d62078763c174b7eb93d4e19a73678d92b0b8ea6aec9b",
     "Escrow": "0x2d3fa1f90c9b8cfd37e208312711caf65eb708f5aac9045936c046f55998c299",
     "Portfolios": "0x4f53d9e5206319952c243f108fd387204d92e08b8b8ff72c106a7becddc55a18",
     "ERC1155Token": "0x26fbb2940acc7ee6c8574c38f6a0150f3c58094c006b7ccf00d851cfb387c701",
-    "ERC1155Trade": "0x395e77fb8c84e2f9eb3efdfc8f2b564c7080ef0d2b79613c14945c17ec312cdf"
+    "ERC1155Trade": "0x694355c2884a2e2c98d10eb0170fafb2dd92a1220d9a5acd8525035109ad5cf4"
   },
-  "gitHash": "5425ccf1ba42c762eac18dcada50c01a834e5928"
+  "gitHash": "f29dd93052668f8c7a8c95706a38e13b6d4cbc30"
 }

--- a/rinkeby.json
+++ b/rinkeby.json
@@ -8,7 +8,7 @@
   "directory": "0xdce848258dFB1bBf34C346Fbe40F10F8a42d2526",
   "erc1155": "0x3a31b8121D810B1D7b3004f94f205E6DFC1bf8d9",
   "erc1155trade": "0xBbA899578bd3fA3DAa863A340f5600797993eF08",
-  "cashMarketLogic": "0x092b95d4A73763C5fA46BD3A5bAf7bd7741724Ad",
+  "cashMarketLogic": "0x5e39d665970a00AA6a31f84B58548c36C4f6B49d",
   "startBlock": 7237041,
   "defaultConfirmations": 3,
   "libraries": {
@@ -18,12 +18,12 @@
   "deployedCodeHash": {
     "Liquidation": "0xf36bdfe65106d4addfa27de6d5200f61c16950bc7e286204184b2a132fe55331",
     "RiskFramework": "0xf9453b18228638bee1e481aab7db30cd30df8ae5bfad3cbb6893cdd3c21281bb",
-    "CashMarket": "0x5044c667b1a47f5138261f97a089eadea1751c7066fdded7487b8c1db087b9dd",
+    "CashMarket": "0x2b87e487335d31b68acc63fceb962b66c901ab56c19b481021d260b29ca7ed46",
     "Directory": "0xdb138f0d75fdc52b8516c5be3716c51c5770d86b68cc9b22213e61905863b413",
     "Escrow": "0xef697b7fd0411052eabad53617ea4ac573a75e8357e784ed0f3bd140ac150c14",
     "Portfolios": "0x544f1c4565150053112021c8157facf2be375ff3b0a9e10150d2b7b1d16aecdc",
     "ERC1155Token": "0x26fbb2940acc7ee6c8574c38f6a0150f3c58094c006b7ccf00d851cfb387c701",
-    "ERC1155Trade": "0x395e77fb8c84e2f9eb3efdfc8f2b564c7080ef0d2b79613c14945c17ec312cdf"
+    "ERC1155Trade": "0x694355c2884a2e2c98d10eb0170fafb2dd92a1220d9a5acd8525035109ad5cf4"
   },
-  "gitHash": "c2282ee77792ad920556020380bffd92e0ab7e1c"
+  "gitHash": "04b9fe47c3f4f373ffa8255a3af9a14e43731a16"
 }

--- a/test/CashMarket.ts
+++ b/test/CashMarket.ts
@@ -190,24 +190,6 @@ describe("Cash Market", () => {
                 futureCash.addLiquidity(maturities[0], WeiPerEther.mul(10), WeiPerEther.mul(10), 0, 100_000_000, BLOCK_TIME_LIMIT)
             ).to.be.revertedWith(ErrorDecoder.encodeError(ErrorCodes.MARKET_INACTIVE));
         });
-
-        it("should allow liquidity to roll", async () => {
-            await escrow.deposit(dai.address, WeiPerEther.mul(40));
-            await futureCash.addLiquidity(maturities[0], WeiPerEther.mul(10), WeiPerEther.mul(10), 0, 100_000_000, BLOCK_TIME_LIMIT);
-            await futureCash.addLiquidity(maturities[1], WeiPerEther.mul(10), WeiPerEther.mul(10), 0, 100_000_000, BLOCK_TIME_LIMIT);
-            await futureCash.addLiquidity(maturities[2], WeiPerEther.mul(10), WeiPerEther.mul(10), 0, 100_000_000, BLOCK_TIME_LIMIT);
-            await futureCash.addLiquidity(maturities[3], WeiPerEther.mul(10), WeiPerEther.mul(10), 0, 100_000_000, BLOCK_TIME_LIMIT);
-
-            // Take futureCash to change the liquidity amounts
-            await escrow.connect(wallet).deposit(dai.address, WeiPerEther.mul(10));
-            await futureCash.connect(wallet).takefCash(maturities[1], WeiPerEther, BLOCK_TIME_LIMIT, 0);
-            await futureCash.connect(wallet).takefCash(maturities[2], WeiPerEther, BLOCK_TIME_LIMIT, 0);
-            await futureCash.connect(wallet).takefCash(maturities[3], WeiPerEther, BLOCK_TIME_LIMIT, 0);
-
-            await fastForwardToMaturity(provider, maturities[1]);
-            maturities = await futureCash.getActiveMaturities();
-            await futureCash.addLiquidity(maturities[3], WeiPerEther.mul(10), WeiPerEther.mul(10), 0, 100_000_000, BLOCK_TIME_LIMIT);
-        }).timeout(50000);
     });
 
     describe("market liquidity limits", async () => {

--- a/test/ERC1155.ts
+++ b/test/ERC1155.ts
@@ -1175,6 +1175,21 @@ describe("ERC1155 Token", () => {
             expect(await escrow.cashBalances(1, wallet2.address)).to.equal(0)
         })
 
+        it("allows deposit for batchOperation when undercollateralized", async () => {
+            await t.setupLiquidity(owner);
+            await t.borrowAndWithdraw(wallet2, parseEther("100"), 1.05)
+            // Now under collateralized
+            await t.chainlink.setAnswer(parseEther("1"))
+            await erc1155trade.connect(wallet2).batchOperation(
+                wallet2.address,
+                BLOCK_TIME_LIMIT,
+                [{ currencyId: 1, amount: parseEther("1") }],
+                []
+            )
+
+            expect(await escrow.cashBalances(1, wallet2.address)).to.equal(parseEther("1"))
+        });
+
         /*
         it("allows trade (move lend) for batchOperationWithdraw [takeCurrentCash, takefCash]", async () => {
             // Not possible unless cash positions can go temporarily negative

--- a/test/ERC1155.ts
+++ b/test/ERC1155.ts
@@ -867,6 +867,319 @@ describe("ERC1155 Token", () => {
             expect(await escrow.cashBalances(CURRENCY.DAI, wallet2.address)).to.equal(parseEther("10"));
         });
 
+        it("allows roll for batchOperation [addLiquidity]", async () => {
+            await t.setupLiquidity(wallet, 0.5, parseEther("100"));
+            await fastForwardToMaturity(provider, maturities[0])
+            const slippage = defaultAbiCoder.encode(['uint32', 'uint32', 'uint128'], [0, 100_000_000, parseEther("100")]);
+
+            await erc1155trade.connect(wallet).batchOperation(
+                wallet.address,
+                BLOCK_TIME_LIMIT,
+                [],
+                [{ 
+                    tradeType: TradeType.AddLiquidity, 
+                    cashGroup: 1,
+                    maturity: maturities[1],
+                    amount: parseEther("100"),
+                    slippageData: slippage
+                }]
+            );
+
+            expect(await t.hasLiquidityToken(wallet, maturities[1], parseEther("100"))).to.be.true;
+            expect(await t.hasLiquidityToken(wallet, maturities[0], parseEther("100"))).to.be.false;
+        })
+
+        it("allows roll for batchOperation [takefCash]", async () => {
+            await t.setupLiquidity(owner, 0.5, parseEther("10000"), [0, 1]);
+
+            await erc1155trade.connect(wallet2).batchOperationWithdraw(
+                wallet2.address,
+                BLOCK_TIME_LIMIT,
+                [{ currencyId: 1, amount: parseEther("100") }],
+                [{ 
+                    tradeType: TradeType.TakeFutureCash, 
+                    cashGroup: 1,
+                    maturity: maturities[0],
+                    amount: parseEther("100"),
+                    slippageData: "0x"
+                }],
+                [{
+                    to: wallet2.address,
+                    currencyId: 1,
+                    amount: 0
+                }],
+            );
+
+            await fastForwardToMaturity(provider, maturities[0])
+            await erc1155trade.connect(wallet2).batchOperationWithdraw(
+                wallet2.address,
+                BLOCK_TIME_LIMIT,
+                [],
+                [{ 
+                    tradeType: TradeType.TakeFutureCash, 
+                    cashGroup: 1,
+                    maturity: maturities[1],
+                    amount: parseEther("100"),
+                    slippageData: "0x"
+                }],
+                [{
+                    to: wallet2.address,
+                    currencyId: 1,
+                    amount: 0
+                }],
+            );
+            expect(await t.hasCashReceiver(wallet2, maturities[1], parseEther("100"))).to.be.true;
+        })
+
+        it("withdraws exact amount for batchOperationWithdraw w/ ETH cash [takeCurrentCash]", async () => {
+            await t.setupLiquidity(owner, 0.5, parseEther("10000"), [0, 1]);
+            await escrow.connect(wallet2).depositEth({ value: parseEther("10")})
+            const daiBalance = await dai.balanceOf(wallet2.address)
+            await erc1155trade.connect(wallet2).batchOperationWithdraw(
+                wallet2.address,
+                BLOCK_TIME_LIMIT,
+                [],
+                [{ 
+                    tradeType: TradeType.TakeCollateral, 
+                    cashGroup: 1,
+                    maturity: maturities[0],
+                    amount: parseEther("100"),
+                    slippageData: "0x"
+                }],
+                [{
+                    to: wallet2.address,
+                    currencyId: 1,
+                    amount: 0
+                }],
+            );
+            expect(await escrow.cashBalances(CURRENCY.DAI, wallet2.address)).to.equal(0);
+            expect(await dai.balanceOf(wallet2.address)).to.be.above(daiBalance)
+        });
+
+        it("withdraws exact amount for batchOperationWithdraw w/ Dai cash [takeCurrentCash]", async () => {
+            await t.setupLiquidity(owner, 0.5, parseEther("10000"), [0, 1]);
+            await escrow.connect(wallet2).deposit(dai.address, parseEther("100"))
+            const daiBalance = await dai.balanceOf(wallet2.address)
+            await erc1155trade.connect(wallet2).batchOperationWithdraw(
+                wallet2.address,
+                BLOCK_TIME_LIMIT,
+                [],
+                [{ 
+                    tradeType: TradeType.TakeCollateral, 
+                    cashGroup: 1,
+                    maturity: maturities[0],
+                    amount: parseEther("100"),
+                    slippageData: "0x"
+                }],
+                [{
+                    to: wallet2.address,
+                    currencyId: 1,
+                    amount: 0
+                }],
+            );
+
+            expect(await escrow.cashBalances(CURRENCY.DAI, wallet2.address)).to.equal(parseEther("100"));
+            expect(await dai.balanceOf(wallet2.address)).to.be.above(daiBalance)
+        });
+
+        it("allows trade (move liquidity) for batchOperationWithdraw [removeLiquidity, addLiquidity]", async () => {
+            await t.setupLiquidity(owner, 0.5, parseEther("10000"), [0, 1]);
+            // This will move the market so there is some residual cash
+            await erc1155trade.connect(wallet2).batchOperationWithdraw(
+                wallet2.address,
+                BLOCK_TIME_LIMIT,
+                [{ currencyId: 1, amount: parseEther("100") }],
+                [{ 
+                    tradeType: TradeType.TakeFutureCash, 
+                    cashGroup: 1,
+                    maturity: maturities[0],
+                    amount: parseEther("100"),
+                    slippageData: "0x"
+                }],
+                [{
+                    to: wallet2.address,
+                    currencyId: 1,
+                    amount: 0
+                }],
+            );
+
+            const slippage = defaultAbiCoder.encode(['uint32', 'uint32', 'uint128'], [0, 100_000_000, parseEther("1000")]);
+            await erc1155trade.connect(owner).batchOperationWithdraw(
+                owner.address,
+                BLOCK_TIME_LIMIT,
+                [],
+                [{ 
+                    tradeType: TradeType.RemoveLiquidity, 
+                    cashGroup: 1,
+                    maturity: maturities[1],
+                    amount: parseEther("1000"),
+                    slippageData: "0x"
+                }, {
+                    tradeType: TradeType.AddLiquidity, 
+                    cashGroup: 1,
+                    maturity: maturities[2],
+                    amount: parseEther("1000"), // It would be nice if this specified the amount above...
+                    slippageData: slippage
+                }],
+                [{
+                    to: wallet2.address,
+                    currencyId: 1,
+                    amount: 0
+                }],
+            );
+
+            expect(await t.hasLiquidityToken(owner, maturities[1], parseEther("9000"))).to.be.true;
+            expect(await t.hasLiquidityToken(owner, maturities[2], parseEther("1000"))).to.be.true;
+        });
+
+        it("allows trade (move lend) for batchOperationWithdraw [takeCurrentCash, takefCash]", async () => {
+            await t.setupLiquidity(owner, 0.5, parseEther("10000"), [0, 1]);
+
+            await erc1155trade.connect(wallet2).batchOperationWithdraw(
+                wallet2.address,
+                BLOCK_TIME_LIMIT,
+                [{ currencyId: 1, amount: parseEther("100") }],
+                [{ 
+                    tradeType: TradeType.TakeFutureCash, 
+                    cashGroup: 1,
+                    maturity: maturities[0],
+                    amount: parseEther("100"),
+                    slippageData: "0x"
+                }],
+                [{
+                    to: wallet2.address,
+                    currencyId: 1,
+                    amount: 0
+                }],
+            );
+
+            await erc1155trade.connect(wallet2).batchOperationWithdraw(
+                wallet2.address,
+                BLOCK_TIME_LIMIT,
+                [],
+                [{ 
+                    tradeType: TradeType.TakeCollateral, 
+                    cashGroup: 1,
+                    maturity: maturities[0],
+                    amount: parseEther("100"),
+                    slippageData: "0x"
+                }, {
+                    tradeType: TradeType.TakeFutureCash, 
+                    cashGroup: 1,
+                    maturity: maturities[1],
+                    amount: parseEther("100"),
+                    slippageData: "0x"
+                }],
+                [{
+                    to: wallet2.address,
+                    currencyId: 1,
+                    amount: 0
+                }],
+            );
+
+            expect(await t.hasCashReceiver(wallet2, maturities[1], parseEther("100"))).to.be.true;
+            expect(await t.hasCashPayer(wallet2, maturities[0])).to.be.false
+            expect(await t.hasCashReceiver(wallet2, maturities[0])).to.be.false
+        })
+
+        it("allows trade (repay borrow) for batchOperationWithdraw [takefCash]", async () => {
+            await t.setupLiquidity(owner, 0.5, parseEther("10000"), [0, 1]);
+
+            await erc1155trade.connect(wallet2).batchOperationWithdraw(
+                wallet2.address,
+                BLOCK_TIME_LIMIT,
+                [{ currencyId: 0, amount: parseEther("10") }],
+                [{ 
+                    tradeType: TradeType.TakeCollateral, 
+                    cashGroup: 1,
+                    maturity: maturities[0],
+                    amount: parseEther("100"),
+                    slippageData: "0x"
+                }],
+                [{
+                    to: wallet2.address,
+                    currencyId: 1,
+                    amount: 0
+                }],
+            );
+
+            await erc1155trade.connect(wallet2).batchOperationWithdraw(
+                wallet2.address,
+                BLOCK_TIME_LIMIT,
+                [{ currencyId: 1, amount: parseEther("100") }],
+                [{ 
+                    tradeType: TradeType.TakeFutureCash, 
+                    cashGroup: 1,
+                    maturity: maturities[0],
+                    amount: parseEther("100"),
+                    slippageData: "0x"
+                }],
+                [{
+                    to: wallet2.address,
+                    currencyId: 1,
+                    amount: 0
+                }, {
+                    to: wallet2.address,
+                    currencyId: 0,
+                    amount: parseEther("10")
+                }],
+            );
+
+            expect(await t.hasCashPayer(wallet2, maturities[0])).to.be.false
+            expect(await t.hasCashReceiver(wallet2, maturities[0])).to.be.false
+            expect(await escrow.cashBalances(0, wallet2.address)).to.equal(0)
+            expect(await escrow.cashBalances(1, wallet2.address)).to.equal(0)
+        })
+
+        it("allows trade (withdraw loan) for batchOperationWithdraw [takefCash]", async () => {
+            await t.setupLiquidity(owner, 0.5, parseEther("10000"), [0]);
+
+            await erc1155trade.connect(wallet2).batchOperationWithdraw(
+                wallet2.address,
+                BLOCK_TIME_LIMIT,
+                [{ currencyId: 1, amount: parseEther("100") }],
+                [{ 
+                    tradeType: TradeType.TakeFutureCash, 
+                    cashGroup: 1,
+                    maturity: maturities[0],
+                    amount: parseEther("100"),
+                    slippageData: "0x"
+                }],
+                [{
+                    to: wallet2.address,
+                    currencyId: 1,
+                    amount: 0
+                }],
+            );
+
+            await erc1155trade.connect(wallet2).batchOperationWithdraw(
+                wallet2.address,
+                BLOCK_TIME_LIMIT,
+                [],
+                [{ 
+                    tradeType: TradeType.TakeCollateral, 
+                    cashGroup: 1,
+                    maturity: maturities[0],
+                    amount: parseEther("100"),
+                    slippageData: "0x"
+                }],
+                [{
+                    to: wallet2.address,
+                    currencyId: 1,
+                    amount: 0
+                }],
+            );
+
+            expect(await t.hasCashPayer(wallet2, maturities[0])).to.be.false
+            expect(await t.hasCashReceiver(wallet2, maturities[0])).to.be.false
+            expect(await escrow.cashBalances(1, wallet2.address)).to.equal(0)
+        })
+
+        /*
+        it("allows trade (move lend) for batchOperationWithdraw [takeCurrentCash, takefCash]", async () => {
+            // Not possible unless cash positions can go temporarily negative
+        })
+        */
     });
 
     describe("block trades", async () => {


### PR DESCRIPTION
This patch updates the ERC1155 Token contract to fix two UX issues:
1. After loans matured, accounts would not be able to roll their cash balances into new maturities until they settled their assets. The fix for this is to move the `settledMaturedAssets` call to the beginning of the batchOperation call and out of the freeCollateral call at the end of the method.
2. Also removed the `settleMaturedAssets` call from `_addLiquidity` on the CashMarket.sol contract because it is now redundant and gas inefficient when adding liquidity to multiple markets in batch.
3. Fixed an issue when borrowing and no deposit is made, the contract did not withdraw the corresponding amount.